### PR TITLE
Add Last Modified and ETag headers to component responses

### DIFF
--- a/lib/alephant/storage.rb
+++ b/lib/alephant/storage.rb
@@ -1,6 +1,7 @@
 require "alephant/storage/version"
 require "alephant/logger"
 require "aws-sdk"
+require "time"
 
 module Alephant
   class Storage
@@ -75,7 +76,7 @@ module Alephant
     def add_custom_meta(object)
       {
         :head_ETag            => object.etag,
-        :"head_Last-Modified" => object.last_modified
+        :"head_Last-Modified" => Time.parse(object.last_modified).httpdate
       }
     end
   end

--- a/lib/alephant/storage.rb
+++ b/lib/alephant/storage.rb
@@ -1,7 +1,7 @@
 require "alephant/storage/version"
 require "alephant/logger"
 require "aws-sdk"
-require "time"
+require "date"
 
 module Alephant
   class Storage
@@ -76,7 +76,7 @@ module Alephant
     def add_custom_meta(object)
       {
         :head_ETag            => object.etag,
-        :"head_Last-Modified" => Time.parse(object.last_modified).httpdate
+        :"head_Last-Modified" => DateTime.parse(object.last_modified).httpdate
       }
     end
   end

--- a/lib/alephant/storage.rb
+++ b/lib/alephant/storage.rb
@@ -1,6 +1,6 @@
-require 'alephant/storage/version'
-require 'alephant/logger'
-require 'aws-sdk'
+require "alephant/storage/version"
+require "alephant/logger"
+require "aws-sdk"
 
 module Alephant
   class Storage
@@ -16,7 +16,7 @@ module Alephant
         "event"  => "StorageInitialized",
         "id"     => id,
         "path"   => path,
-        "method" => "#{self.class}#initialize",
+        "method" => "#{self.class}#initialize"
       )
     end
 
@@ -29,7 +29,7 @@ module Alephant
       )
     end
 
-    def put(id, data, content_type = 'text/plain', meta = {})
+    def put(id, data, content_type = "text/plain", meta = {})
       bucket.objects["#{path}/#{id}"].write(
         data,
         {

--- a/lib/alephant/storage.rb
+++ b/lib/alephant/storage.rb
@@ -51,7 +51,7 @@ module Alephant
       object       = bucket.objects["#{path}/#{id}"]
       content      = object.read
       content_type = object.content_type
-      meta_data    = object.metadata.to_h
+      meta_data    = object.metadata.to_h.merge(add_custom_meta(object))
 
       logger.metric "StorageGets"
       logger.info(
@@ -67,6 +67,15 @@ module Alephant
         :content      => content,
         :content_type => content_type,
         :meta         => meta_data
+      }
+    end
+
+    private
+
+    def add_custom_meta(object)
+      {
+        :head_ETag            => object.etag,
+        :"head_Last-Modified" => object.last_modified
       }
     end
   end

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -70,6 +70,8 @@ describe Alephant::Storage do
       expect(s3_object_collection).to receive(:read).and_return("content")
       expect(s3_object_collection).to receive(:content_type).and_return("foo/bar")
       expect(s3_object_collection).to receive(:metadata).and_return({ :foo => :bar})
+      expect(s3_object_collection).to receive(:etag).and_return("foo_123")
+      expect(s3_object_collection).to receive(:last_modified).and_return("Mon, 11 Apr 2016 10:39:57 GMT")
 
       s3_bucket = double()
       expect(s3_bucket).to receive(:objects).and_return(
@@ -84,9 +86,13 @@ describe Alephant::Storage do
       object_hash = instance.get(id)
 
       expected_hash = {
-        :content      => "content",
-        :content_type => "foo/bar",
-        :meta         => { :foo => :bar }
+        :content              => "content",
+        :content_type         => "foo/bar",
+        :meta                 => {
+          :foo                  => :bar,
+          :head_ETag            => "foo_123",
+          :"head_Last-Modified" => "Mon, 11 Apr 2016 10:39:57 GMT"
+        }
       }
 
       expect(object_hash).to eq(expected_hash)

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -70,7 +70,7 @@ describe Alephant::Storage do
       expect(s3_object_collection).to receive(:content_type).and_return("foo/bar" )
       expect(s3_object_collection).to receive(:metadata).and_return({ :foo => :bar })
       expect(s3_object_collection).to receive(:etag).and_return("foo_123")
-      expect(s3_object_collection).to receive(:last_modified).and_return("Mon, 11 Apr 2016 10:39:57 GMT")
+      expect(s3_object_collection).to receive(:last_modified).and_return("2016-04-11 10:39:57 +0000")
 
       s3_bucket = double()
       expect(s3_bucket).to receive(:objects).and_return(

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,5 +1,4 @@
-require 'spec_helper'
-require 'pry'
+require "spec_helper"
 
 describe Alephant::Storage do
   let(:id)   { :id }
@@ -60,7 +59,7 @@ describe Alephant::Storage do
       expect_any_instance_of(AWS::S3).to receive(:buckets).and_return({ id => s3_bucket })
       instance = subject.new(id, path)
 
-      instance.put(id, data, 'foo/bar')
+      instance.put(id, data, "foo/bar")
     end
   end
 
@@ -68,8 +67,8 @@ describe Alephant::Storage do
     it "gets bucket path/id content data" do
       s3_object_collection = double()
       expect(s3_object_collection).to receive(:read).and_return("content")
-      expect(s3_object_collection).to receive(:content_type).and_return("foo/bar")
-      expect(s3_object_collection).to receive(:metadata).and_return({ :foo => :bar})
+      expect(s3_object_collection).to receive(:content_type).and_return("foo/bar" )
+      expect(s3_object_collection).to receive(:metadata).and_return({ :foo => :bar })
       expect(s3_object_collection).to receive(:etag).and_return("foo_123")
       expect(s3_object_collection).to receive(:last_modified).and_return("Mon, 11 Apr 2016 10:39:57 GMT")
 
@@ -86,9 +85,9 @@ describe Alephant::Storage do
       object_hash = instance.get(id)
 
       expected_hash = {
-        :content              => "content",
-        :content_type         => "foo/bar",
-        :meta                 => {
+        :content      => "content",
+        :content_type => "foo/bar",
+        :meta         => {
           :foo                  => :bar,
           :head_ETag            => "foo_123",
           :"head_Last-Modified" => "Mon, 11 Apr 2016 10:39:57 GMT"
@@ -99,4 +98,3 @@ describe Alephant::Storage do
     end
   end
 end
-


### PR DESCRIPTION
The S3 API writes a Last-Modified and ETag header to each file written to S3. So I am making use of the existing values, by returning these in the component meta with the prefix of "head_", as this gets used automatically by Alephant Broker as headers.

https://jira.dev.bbc.co.uk/browse/CONNPOL-3135

![](https://media.giphy.com/media/RnpB82tnBjfYA/giphy.gif)
