### PR TITLE
Fix DateTime parsing by providing as string

### DIFF
--- a/lib/alephant/storage.rb
+++ b/lib/alephant/storage.rb
@@ -76,7 +76,7 @@ module Alephant
     def add_custom_meta(object)
       {
         :head_ETag            => object.etag,
-        :"head_Last-Modified" => DateTime.parse(object.last_modified).httpdate
+        :"head_Last-Modified" => DateTime.parse(object.last_modified.to_s).httpdate
       }
     end
   end

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "date"
 
 describe Alephant::Storage do
   let(:id)   { :id }
@@ -70,7 +71,7 @@ describe Alephant::Storage do
       expect(s3_object_collection).to receive(:content_type).and_return("foo/bar" )
       expect(s3_object_collection).to receive(:metadata).and_return({ :foo => :bar })
       expect(s3_object_collection).to receive(:etag).and_return("foo_123")
-      expect(s3_object_collection).to receive(:last_modified).and_return("2016-04-11 10:39:57 +0000")
+      expect(s3_object_collection).to receive(:last_modified).and_return(DateTime.parse("2016-04-11 10:39:57 +0000"))
 
       s3_bucket = double()
       expect(s3_bucket).to receive(:objects).and_return(


### PR DESCRIPTION
When parsing a DateTime, a string has to be provided. The S3 API provides a DateTime object.

```
undefined method `gsub!' for 2016-04-14 09:49:17 +0000:Time
```

This converts the DateTime to a string before parsing it.

![](https://media.giphy.com/media/oje6kPRIef6Gk/giphy.gif)
